### PR TITLE
wrong arg in path.resolve()

### DIFF
--- a/common.py
+++ b/common.py
@@ -130,7 +130,7 @@ class WorldInterface(QObject):
     def locationImage(self, location):
         """Return the image for the given location."""
         path = schooldir / "Images/Locations" / self.location_images[location]
-        path = path.resolve(strict=True)  # raise error if file is not found
+        path = path.resolve()  # raise error if file is not found
         return path
 
     def peopleAt(self, location):

--- a/gui.py
+++ b/gui.py
@@ -100,7 +100,7 @@ class MainWin(QMainWindow):
         self.setCentralWidget(w)
 
         # configure window
-        self.setWindowTitle("pyprinciple")
+        # self.setWindowTitle("pyprinciple") # it is set by retranslateUi() 
         geom = QDesktopWidget().availableGeometry()
         self.setGeometry(100, 50, 800, 600)
 
@@ -119,8 +119,8 @@ class MainWin(QMainWindow):
         self.location_lbl.setObjectName("text")
         self.location_lbl.setFont(style.location_font)
 
-#        self.gridW.setContentsMargins(0, 0, 0, 0)
-#        gridW.setGeometry(geom)
+        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setGeometry(geom)
         self.energy_bar.setValue(60)
         self.energy_bar.setObjectName("energy")
         self.arousal_bar.setValue(48)
@@ -148,7 +148,7 @@ class MainWin(QMainWindow):
     def retranslateUi(self):
         tra = QApplication.translate
         ctxt = "MainWin"
-        self.setWindowTitle(tra(ctxt, "Main window"))
+        self.setWindowTitle(tra(ctxt, "pyPrinciple"))
         # TODO: use ordered dict instead
         displaystat = ["Education", "Happiness", "Loyalty", "Inhibition",
                        "Lust", "Corruption", "Reputation", "Students", "Money"]


### PR DESCRIPTION
when I try run this hhs interpreter i got: 
```
File "/home/jeremi360/Apps/python/principleproject/pythonsrc/common.py", line 163, in <module>
    schooldir = schooldir.resolve(strict=True)
TypeError: resolve() got an unexpected keyword argument 'strict'
```
I change this line to: `schooldir = schooldir.resolve(True)` and got this:
`TypeError: resolve() takes 1 positional argument but 2 were given`

Then I remove `True` form line and its working now. 